### PR TITLE
solve 03-UiInput in 06-wrappers, redo 03-UiButton in 06-wrappers

### DIFF
--- a/06-wrappers/02-UiButton/components/UiButton.vue
+++ b/06-wrappers/02-UiButton/components/UiButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="tag" class="button" :class="`button_${variant} ${isBlock}`" :type="type">
+  <component :is="tag" class="button" :class="`button_${variant} ${isBlock}`" :type="btnType">
     <slot></slot>
   </component>
 </template>
@@ -19,16 +19,19 @@ export default {
     block: {
       type: Boolean,
     },
+    type: {
+      type: String,
+    },
   },
   computed: {
     isBlock() {
       return this.block ? 'button_block' : '';
     },
-    type() {
-      if (this.tag === 'button' && !this.$attrs.type) {
+    btnType() {
+      if (this.tag === 'button' && !this.type) {
         return 'button';
       } else {
-        return this.$attrs.type;
+        return this.type;
       }
     },
   },

--- a/06-wrappers/03-UiInput/__tests__/UiInput.test.js
+++ b/06-wrappers/03-UiInput/__tests__/UiInput.test.js
@@ -121,7 +121,6 @@ describe('wrappers/UiInput', () => {
       expect(findInput(wrapper).element === document.activeElement).toBeTruthy();
     });
 
-    /*
     describe('Дополнительная часть - модификатор lazy', () => {
       it('UiInput не должен обновлять значение модели в процессе ввода с модификатором lazy', async () => {
         const modelValue = 'SampleText';
@@ -142,6 +141,5 @@ describe('wrappers/UiInput', () => {
         expect(wrapper.emitted('update:modelValue')[0]).toEqual([modelValue]);
       });
     });
-    */
   });
 });

--- a/06-wrappers/03-UiInput/components/UiInput.vue
+++ b/06-wrappers/03-UiInput/components/UiInput.vue
@@ -21,7 +21,7 @@
       }"
       v-bind="$attrs"
       :value="modelValue"
-      @[checkLazyModifier()]="$emit('update:modelValue', $event.target.value)"
+      @[checkLazyModifier]="$emit('update:modelValue', $event.target.value)"
     />
 
     <div class="input-group__icon" v-if="$slots['right-icon']">
@@ -45,7 +45,11 @@ export default {
       type: Boolean,
     },
     modelValue: {
-      type: [String],
+      type: [String, Number],
+    },
+    modelModifiers: {
+      type: Object,
+      default: () => ({}),
     },
   },
   computed: {
@@ -56,21 +60,18 @@ export default {
         return 'input';
       }
     },
-  },
-  methods: {
-    focus() {
-      this.$refs.input.focus();
-    },
     checkLazyModifier() {
-      if (this.$attrs.modelModifiers?.lazy) {
+      if (this.modelModifiers.lazy) {
         return 'change';
       } else {
         return 'input';
       }
     },
   },
-  mounted() {
-    console.log(this.$attrs);
+  methods: {
+    focus() {
+      this.$refs.input.focus();
+    },
   },
 };
 </script>

--- a/06-wrappers/03-UiInput/components/UiInput.vue
+++ b/06-wrappers/03-UiInput/components/UiInput.vue
@@ -1,20 +1,77 @@
 <template>
-  <div class="input-group input-group_icon input-group_icon-left input-group_icon-right">
-    <div class="input-group__icon">
-      <img class="icon" alt="icon" />
+  <div
+    class="input-group"
+    :class="{
+      'input-group_icon': $slots['right-icon'] || $slots['left-icon'],
+      'input-group_icon-left': $slots['left-icon'],
+      'input-group_icon-right': $slots['right-icon'],
+    }"
+  >
+    <div class="input-group__icon" v-if="$slots['left-icon']">
+      <slot name="left-icon"></slot>
     </div>
 
-    <input ref="input" class="form-control form-control_rounded form-control_sm" />
+    <component
+      :is="tag"
+      ref="input"
+      class="form-control"
+      :class="{
+        'form-control_sm': small,
+        'form-control_rounded': rounded,
+      }"
+      v-bind="$attrs"
+      :value="modelValue"
+      @[checkLazyModifier()]="$emit('update:modelValue', $event.target.value)"
+    />
 
-    <div class="input-group__icon">
-      <img class="icon" alt="icon" />
+    <div class="input-group__icon" v-if="$slots['right-icon']">
+      <slot name="right-icon"></slot>
     </div>
   </div>
 </template>
-
 <script>
 export default {
   name: 'UiInput',
+  inheritAttrs: false,
+  emits: ['update:modelValue'],
+  props: {
+    small: {
+      type: Boolean,
+    },
+    rounded: {
+      type: Boolean,
+    },
+    multiline: {
+      type: Boolean,
+    },
+    modelValue: {
+      type: [String],
+    },
+  },
+  computed: {
+    tag() {
+      if (this.multiline) {
+        return 'textarea';
+      } else {
+        return 'input';
+      }
+    },
+  },
+  methods: {
+    focus() {
+      this.$refs.input.focus();
+    },
+    checkLazyModifier() {
+      if (this.$attrs.modelModifiers?.lazy) {
+        return 'change';
+      } else {
+        return 'input';
+      }
+    },
+  },
+  mounted() {
+    console.log(this.$attrs);
+  },
 };
 </script>
 


### PR DESCRIPTION
Григорий, доброго дня!

Вопрос 1: 
**$refs['firstInput'].$refs['input']** - синтаксис такого рода - это техническое требование или предпочтение разработчика / требование командного стиля? 
Насколько я знаю, мы обязаны заключать поля объектов в квадратные скобки, если имя свойства не является одним словом, н-ер, **first-input / first input**.

Вопрос 2:
Насколько правильно решен пункт с **v-model.lazy**?
Единственный способ избежать проблем с "полуреактивностью" $attr - это записать логику в методы?
Насколько корректно прям в шаблоне использовать вызов функции для получения имени динамического атрибута события change / input?

Вопрос 3: 
Больше философский вопрос! 
Зачем вообще Vue сделал модификатор lazy, который не работает "из коробки"? Это их баг и его планируется решить в следующих релизах? 
Или здесь есть какой-то технический подвох, что они поступили таким способом?


